### PR TITLE
Rewrite FSMs

### DIFF
--- a/actions.ts
+++ b/actions.ts
@@ -7,7 +7,11 @@ import { TodoStore } from "./todoStore";
  * but that name is already used to refer to DOM events. Actions are similar to
  * input symbols in the context of finite state machines.
  */
-export type Action = { tag: ActionTag; } | TodosLoaded | LoggedIn | UsernameLoaded
+export type Action =  BasicAction | ComplexAction;
+
+type BasicAction = { tag: Exclude<ActionTag, ComplexAction["tag"]> }
+
+type ComplexAction = TodosLoaded | LoggedIn | UsernameLoaded;
 
 /** An ActionTag identifies a type of action. */
 export enum ActionTag {

--- a/appBarRightFsm.ts
+++ b/appBarRightFsm.ts
@@ -1,34 +1,41 @@
-import { Action, ActionTag, LoggedIn, UsernameLoaded } from "./actions";
-import type { Dispatcher } from "./dispatcher";
+import { Action, ActionTag } from "./actions";
+import { assertNever } from "./assertNever";
 import { newFsm } from "./fsm";
 
 export type AppBarRightFsm = ReturnType<typeof newAppBarRightFsm>;
 
-export function newAppBarRightFsm(dispatcher: Dispatcher) {
-  return newFsm(dispatcher, emptyState);
+export function newAppBarRightFsm() {
+  return newFsm(emptyState, transition);
 }
 
-export enum AppBarRightStateTag {
-  Empty,
-  User
-}
+export enum StateTag { Empty, User }
 
-export type AppBarRightState = typeof emptyState | ReturnType<typeof newUserState>;
+type State = typeof emptyState | ReturnType<typeof newUserState>;
 
-const emptyState = {
-  tag: AppBarRightStateTag.Empty,
-  transitions: [
-    [ActionTag.UsernameLoaded, (a: Action) => newUserState((a as UsernameLoaded).username)],
-    [ActionTag.LoggedIn, (a: Action) => newUserState((a as LoggedIn).username)],
-  ],
-} as const;
+const emptyState = { tag: StateTag.Empty } as const;
 
 function newUserState(username: string) {
-  return {
-    tag: AppBarRightStateTag.User,
-    transitions: [
-      [ActionTag.LogoutClicked, () => emptyState],
-    ],
-    username,
-  } as const;
+  return { tag: StateTag.User, username } as const;
+}
+
+export function transition(state: State, action: Action): State | undefined {
+  switch (state.tag) {
+    case StateTag.Empty:
+
+      switch (action.tag) {
+        case ActionTag.UsernameLoaded: return newUserState(action.username);
+        case ActionTag.LoggedIn: return newUserState(action.username);
+      }
+
+      break;
+    case StateTag.User:
+
+      switch (action.tag) {
+        case ActionTag.LogoutClicked: return emptyState;
+      }
+
+      break;
+    default: assertNever(state);
+  }
+  return undefined;
 }

--- a/assertNever.ts
+++ b/assertNever.ts
@@ -1,0 +1,16 @@
+/**
+ * assertNever helps with exhaustiveness checking. For example:
+ * 
+ * type X = "a" | "b" | "c";
+ * declare const x: X;
+ * if (x === "a") {
+ *   // ...
+ * } else if (x === "b") {
+ *   // ...
+ * }
+ * // The line below results in a compile-time error due to unhandled case "c".
+ * assertNever(x);
+ */
+export function assertNever(x: never, errorMsg?: string): never {
+  throw new Error(errorMsg);
+}

--- a/dispatcher.ts
+++ b/dispatcher.ts
@@ -1,41 +1,21 @@
-import { Action, ActionTag } from "./actions";
-
-type Handler = (a: Action) => void;
+import { Action } from "./actions";
+import { AppBarCenterFsm } from "./appBarCenterFsm";
+import { AppBarRightFsm } from "./appBarRightFsm";
+import { ContentFsm } from "./contentFsm";
 
 export type Dispatcher = ReturnType<typeof newDispatcher>;
 
-export function newDispatcher() {
-
-  const handlerMap = new Map<ActionTag, Set<Handler>>();
-
-  // register associates a Handler with an ActionTag. register returns a
-  // function that unregisters the Handler.
-  function register(tag: ActionTag, handler: Handler) {
-    let h = handlerMap.get(tag);
-    if (h === undefined) {
-      h = new Set();
-      handlerMap.set(tag, h);
-    }
-    h.add(handler);
-    return () => {
-      h!.delete(handler);
-      if (h!.size === 0) {
-        handlerMap.delete(tag);
-      }
-    }
+export function newDispatcher(
+  appBarCenterFsm: AppBarCenterFsm,
+  appBarRightFsm: AppBarRightFsm,
+  contentFsm: ContentFsm
+) {
+  
+  function dispatch(action: Action) {
+    appBarCenterFsm.dispatch(action);
+    appBarRightFsm.dispatch(action);
+    contentFsm.dispatch(action);
   }
 
-  // dispatch calls all Handlers associated with the given Action's tag.
-  function dispatch(a: Action) {
-    console.log(`dispatch ${ActionTag[a.tag]}`);
-    const h = handlerMap.get(a.tag)
-    if (h !== undefined) {
-      h.forEach((handler) => handler(a));
-    }
-  }
-
-  return {
-    register,
-    dispatch
-  };
+  return { dispatch }
 }


### PR DESCRIPTION
- Rewrite the FSM+dispatcher apparatus. The new implementation is easier to type check, and easier for me to understand. It is also a more restrictive design. E.g., it is no longer possible to modify FSMs at run-time, or register arbitrary Action handlers.
- Make type Action more restrictive. E.g., previously both TodosLoaded and { tag: ActionTag.TodosLoaded } were assignable to Action. Now only the former is assignable.
- Add assertNever to help with compile-time exhaustiveness checking, and add such checks.
- Document useSubscribeToFsm.